### PR TITLE
Fix: Handle 404 responses properly when loading answers.json

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,13 @@
                     return {};
                 }),
             fetch('/answers.json')
-                .then(response => response.json())
+                .then(response => {
+                    if (!response.ok) {
+                        // If file doesn't exist (404) or other error, return empty object
+                        return {};
+                    }
+                    return response.json();
+                })
                 .catch(() => ({}))
         ])
         .then(([surveyJson, persistedAnswers]) => {


### PR DESCRIPTION


## Bug Fix: Prevent 404 Error Responses from Corrupting Quiz Answers

### Problem
When the quiz application starts, it fetches `/answers.json` to load any previously saved answers. If this file doesn't exist (common on first run), the server returns a 404 response with JSON content:
```json
{"error": "Not Found"}
```

The frontend incorrectly treated this error response as valid answer data, causing corrupted `answers.json` files:
```json
{
  "error": "Not Found",                    ← ❌ Server error mixed with quiz data
  "civilwar": {
    "value": "1861-1865",
    "correctAnswer": "1861-1865", 
    "isCorrect": true
  },
  "capital": {
    "value": "Paris",
    "correctAnswer": "Paris",
    "isCorrect": true
  }
}
```

This corruption caused the `format_answers.py` script to crash:

```text
AttributeError: 'str' object has no attribute 'get'
```

### Root Cause
The frontend fetch logic was not checking `response.ok` before parsing JSON:
```javascript
fetch('/answers.json')
    .then(response => response.json())  // ❌ Parses error responses as valid data
    .catch(() => ({}))  // Only catches network/parsing errors, not 404s
```

### Solution
Modified the fetch logic to properly handle HTTP error responses:
```javascript
fetch('/answers.json')
    .then(response => {
        if (!response.ok) {
            // If file doesn't exist (404) or other error, return empty object
            return {};
        }
        return response.json();
    })
    .catch(() => ({}))
```

### Testing
- ✅ Deleted `answers.json` and verified clean startup without error pollution
- ✅ Confirmed quiz answers save correctly without error objects
- ✅ Verified `format_answers.py` runs successfully after taking quiz
- ✅ No functional changes to quiz behavior or server logic